### PR TITLE
[CLOUD-4610] Add gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,32 @@
+name: gitleaks
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the scan is complete
+      - name: Install and run gitleaks (non-blocking)
+        continue-on-error: true # reports findings, does not fail the PR yet
+        run: |
+          VERSION=8.28.0
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          code=0
+          ./gitleaks detect --source . --redact -v --config .gitleaks.toml --report-format json --report-path gitleaks-report.json || code=$?
+          count=$(jq 'length' gitleaks-report.json 2>/dev/null || echo 0)
+          {
+            echo "## gitleaks: ${count} finding(s)"
+            if [ "$count" -gt 0 ]; then
+              echo ""
+              echo "| Rule | File | Line | Commit |"
+              echo "| --- | --- | --- | --- |"
+              jq -r '.[] | "| \(.RuleID) | \(.File) | \(.StartLine) | \(.Commit[0:8]) |"' gitleaks-report.json
+            else
+              echo "No findings."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $code

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# Gitleaks config for sambanova-typescript. Extends the built-in default ruleset.
+title = "sambanova-typescript gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Stainless-generated SDK metadata (not credentials)"
+paths = [
+  '''\.stats\.yml$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Adds gitleaks secret scanning to this repo.

- `.gitleaks.toml` — gitleaks config; extends the default ruleset (allowlists the Stainless `.stats.yml` metadata).
- `.pre-commit-config.yaml` — adds the gitleaks hook so secrets are caught before they're committed.
- `.github/workflows/gitleaks.yml` — runs gitleaks on PRs and pushes to `main` via the gitleaks binary (org Actions allowlist blocks third-party actions). Non-blocking for now: reports findings without failing the build.

Part of the org-wide secret-scanning rollout (CLOUD-4610).
